### PR TITLE
Propagate log directory to cartridge-cli command

### DIFF
--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -102,8 +102,10 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
     private static final String ENV_TARANTOOL_SERVER_GID = "TARANTOOL_SERVER_GID";
     private static final String ENV_TARANTOOL_WORKDIR = "TARANTOOL_WORKDIR";
     private static final String ENV_TARANTOOL_RUNDIR = "TARANTOOL_RUNDIR";
+    private static final String ENV_TARANTOOL_LOGDIR = "TARANTOOL_LOGDIR";
     private static final String ENV_TARANTOOL_DATADIR = "TARANTOOL_DATADIR";
     private static final String ENV_TARANTOOL_INSTANCES_FILE = "TARANTOOL_INSTANCES_FILE";
+    private static final String ENV_TARANTOOL_CLUSTER_COOKIE = "TARANTOOL_CLUSTER_COOKIE";
 
     private final CartridgeConfigParser instanceFileParser;
     private final TarantoolContainerClientHelper clientHelper;
@@ -239,8 +241,10 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
                 ENV_TARANTOOL_SERVER_GID,
                 ENV_TARANTOOL_WORKDIR,
                 ENV_TARANTOOL_RUNDIR,
+                ENV_TARANTOOL_LOGDIR,
                 ENV_TARANTOOL_DATADIR,
-                ENV_TARANTOOL_INSTANCES_FILE
+                ENV_TARANTOOL_INSTANCES_FILE,
+                ENV_TARANTOOL_CLUSTER_COOKIE
         )) {
             String variableValue = System.getenv(envVariable);
             if (variableValue != null && !args.containsKey(envVariable)) {

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,4 +1,4 @@
-ARG TARANTOOL_VERSION=2.10.5
+ARG TARANTOOL_VERSION=2.11.0
 FROM tarantool/tarantool:${TARANTOOL_VERSION}-centos7 AS cartridge-base
 
 # system preparations because docker mount directory as a root
@@ -8,19 +8,28 @@ USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
 RUN groupadd $TARANTOOL_SERVER_GROUP && useradd -m -s /bin/bash $TARANTOOL_SERVER_USER || true
 
 # install dependencies
-RUN yum -y install cmake make gcc gcc-c++ git unzip cartridge-cli && \
+# a yum bug requires setting ulimit, see https://bugzilla.redhat.com/show_bug.cgi?id=1537564
+RUN ulimit -n 1024 && \
+    yum -y install cmake make gcc gcc-c++ git unzip cartridge-cli && \
     yum clean all
 RUN cartridge version
 
-# build
+# build and run
+FROM cartridge-base AS cartridge-app
 ARG CARTRIDGE_SRC_DIR="cartridge"
 ARG TARANTOOL_WORKDIR="/app"
+ARG TARANTOOL_RUNDIR="/tmp/run"
+ARG TARANTOOL_DATADIR="/tmp/data"
+ARG TARANTOOL_LOGDIR="/tmp/log"
+ARG TARANTOOL_INSTANCES_FILE="./instances.yml"
+ARG TARANTOOL_CLUSTER_COOKIE="testapp-cluster-cookie"
+ENV TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR
+ENV TARANTOOL_RUNDIR=$TARANTOOL_RUNDIR
+ENV TARANTOOL_DATADIR=$TARANTOOL_DATADIR
+ENV TARANTOOL_LOGDIR=$TARANTOOL_LOGDIR
+ENV TARANTOOL_INSTANCES_FILE=$TARANTOOL_INSTANCES_FILE
+ENV TARANTOOL_CLUSTER_COOKIE=$TARANTOOL_CLUSTER_COOKIE
 COPY $CARTRIDGE_SRC_DIR $TARANTOOL_WORKDIR
 WORKDIR $TARANTOOL_WORKDIR
-RUN cartridge build --verbose
-
-ENV TARANTOOL_RUNDIR="/tmp/run"
-ENV TARANTOOL_DATADIR="/tmp/data"
-ENV TARANTOOL_INSTANCES_FILE="./instances.yml"
-
-CMD cartridge build && cartridge start --run-dir=$TARANTOOL_RUNDIR --data-dir=$TARANTOOL_DATADIR --cfg=$TARANTOOL_INSTANCES_FILE
+CMD cartridge build && cartridge start --run-dir=$TARANTOOL_RUNDIR --data-dir=$TARANTOOL_DATADIR \
+    --log-dir=$TARANTOOL_LOGDIR --cfg=$TARANTOOL_INSTANCES_FILE


### PR DESCRIPTION
In this patch:

 - propagate log directory to cartridge CLI so the logs are not created in the local directory
 - fix problems with default Dockerfile on RedHat-like systems