### PR TITLE
Fix startup timeout in the Cartridge container tests

### DIFF
--- a/src/test/java/org/testcontainers/containers/TarantoolCartridgeBootstrapFromLuaWithFixedPortsTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolCartridgeBootstrapFromLuaWithFixedPortsTest.java
@@ -26,7 +26,7 @@ public class TarantoolCartridgeBootstrapFromLuaWithFixedPortsTest {
                     "cartridge/instances_fixedport.yml",
                     "cartridge/topology_fixedport.lua")
                     .withEnv("TARANTOOL_INSTANCES_FILE", "instances_fixedport.yml")
-                    .withStartupTimeout(Duration.ofSeconds(300))
+                    .withStartupTimeout(Duration.ofMinutes(5))
                     .withUseFixedPorts(true)
                     .withAPIPort(18081)
                     .withRouterPort(13301)
@@ -48,7 +48,8 @@ public class TarantoolCartridgeBootstrapFromLuaWithFixedPortsTest {
                              "cartridge/incorrect_topology.lua")
                              .withLogConsumer(new Slf4jLogConsumer(
                                      LoggerFactory.getLogger(
-                                             TarantoolCartridgeBootstrapFromLuaWithFixedPortsTest.class)))) {
+                                             TarantoolCartridgeBootstrapFromLuaWithFixedPortsTest.class)))
+                             .withStartupTimeout(Duration.ofMinutes(5))) {
             ContainerLaunchException ex = assertThrows(ContainerLaunchException.class, testContainer::start);
             Throwable cause = ex.getCause();
             assertEquals(RetryCountExceededException.class, cause.getClass());

--- a/src/test/java/org/testcontainers/containers/TarantoolCartridgeBootstrapFromYamlTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolCartridgeBootstrapFromYamlTest.java
@@ -25,7 +25,7 @@ public class TarantoolCartridgeBootstrapFromYamlTest {
                     "cartridge",
                     "cartridge/instances.yml",
                     "cartridge/replicasets.yml")
-                    .withStartupTimeout(Duration.ofSeconds(300))
+                    .withStartupTimeout(Duration.ofMinutes(5))
                     .withLogConsumer(new Slf4jLogConsumer(
                             LoggerFactory.getLogger(TarantoolCartridgeBootstrapFromYamlTest.class)));
 


### PR DESCRIPTION
Temporarily increase the timeout for tests with cartridge container to exclude the influence of long build time on the correct execution of tests. 

- Correction after #86.


I haven't forgotten about:
- [x] Tests
- [ ] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #90.