### PR TITLE
Add Tarantool 3 support and matrix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,11 +91,12 @@ jobs:
           TARANTOOL_SERVER_USER: root
           TARANTOOL_SERVER_GROUP: root
         run: ./mvnw -B test -P tarantool-container -Djacoco.destFile=target/jacoco-mt.exec --file pom.xml
-        - name: Upload jacoco exec results
-          uses: actions/upload-artifact@v2
-          with:
-            name: tests-mt-jacoco
-            path: "**/jacoco-mt.exec"
+
+      - name: Upload jacoco exec results
+        uses: actions/upload-artifact@v2
+        with:
+          name: tests-mt-jacoco
+          path: "**/jacoco-mt.exec"
 
   merge-jacoco-report:
     name: Jacoco Merge Results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,7 +90,12 @@ jobs:
           TARANTOOL_VERSION: ${{ matrix.tarantool-version }}
           TARANTOOL_SERVER_USER: root
           TARANTOOL_SERVER_GROUP: root
-        run: ./mvnw -B test -P tarantool-container --file pom.xml
+        run: ./mvnw -B test -P tarantool-container -Djacoco.destFile=target/jacoco-mt.exec --file pom.xml
+        - name: Upload jacoco exec results
+          uses: actions/upload-artifact@v2
+          with:
+            name: tests-mt-jacoco
+            path: "**/jacoco-mt.exec"
 
   merge-jacoco-report:
     name: Jacoco Merge Results
@@ -116,6 +121,11 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: tests-ee-jacoco
+          path: .
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: tests-mt-jacoco
           path: .
 
       - name: merge results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
     branches: [ master ]
 
 jobs:
-  tests-ce:
+  tests-cartridge-container:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -26,20 +26,20 @@ jobs:
           cache: 'maven'
 
       - name: Build and run unit tests
-        run: ./mvnw -B verify -Djacoco.destFile=target/jacoco-ce.exec --file pom.xml
+        run: ./mvnw -B verify -Djacoco.destFile=target/jacoco-cartridge-container.exec --file pom.xml
 
       - name: Run integration tests
         env:
           TARANTOOL_SERVER_USER: root
           TARANTOOL_SERVER_GROUP: root
           TARANTOOL_VERSION: "2.11.2-centos7"
-        run: ./mvnw -B test -P integration -Djacoco.destFile=target/jacoco-ce.exec --file pom.xml
+        run: ./mvnw -B test -P integration -Djacoco.destFile=target/jacoco-cartridge-container.exec --file pom.xml
 
       - name: Upload jacoco exec results
         uses: actions/upload-artifact@v2
         with:
-          name: tests-ce-jacoco
-          path: "**/jacoco-ce.exec"
+          name: tests-cartridge-container-jacoco
+          path: "**/jacoco-cartridge-container.exec"
 
   tests-ee:
     runs-on: ubuntu-latest
@@ -68,7 +68,7 @@ jobs:
           name: tests-ee-jacoco
           path: "**/jacoco-ee.exec"
 
-  tests-matrix:
+  tests-tarantool-container:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -90,18 +90,18 @@ jobs:
           TARANTOOL_VERSION: ${{ matrix.tarantool-version }}
           TARANTOOL_SERVER_USER: root
           TARANTOOL_SERVER_GROUP: root
-        run: ./mvnw -B test -P tarantool-container -Djacoco.destFile=target/jacoco-mt.exec --file pom.xml
+        run: ./mvnw -B test -P tarantool-container -Djacoco.destFile=target/jacoco-tarantool-container.exec --file pom.xml
 
       - name: Upload jacoco exec results
         uses: actions/upload-artifact@v2
         with:
-          name: tests-mt-jacoco
-          path: "**/jacoco-mt.exec"
+          name: tests-tarantool-container-jacoco
+          path: "**/jacoco-tarantool-container.exec"
 
   merge-jacoco-report:
     name: Jacoco Merge Results
     needs:
-      - tests-ce
+      - tests-cartridge-container
       - tests-ee
     runs-on: ubuntu-latest
     steps:
@@ -116,7 +116,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: tests-ce-jacoco
+          name: tests-cartridge-container-jacoco
           path: .
 
       - uses: actions/download-artifact@v2
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/download-artifact@v2
         with:
-          name: tests-mt-jacoco
+          name: tests-tarantool-container-jacoco
           path: .
 
       - name: merge results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           TARANTOOL_SERVER_USER: root
           TARANTOOL_SERVER_GROUP: root
+          TARANTOOL_VERSION: "2.11.2-centos7"
         run: ./mvnw -B test -P integration -Djacoco.destFile=target/jacoco-ce.exec --file pom.xml
 
       - name: Upload jacoco exec results
@@ -66,6 +67,30 @@ jobs:
         with:
           name: tests-ee-jacoco
           path: "**/jacoco-ee.exec"
+
+  tests-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      matrix:
+        tarantool-version: [ "1.x-centos7", "2.11.2-centos7", "3.0.1" ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+          cache: 'maven'
+
+      - name: Build and run integration matrix tests
+        env:
+          TARANTOOL_VERSION: ${{ matrix.tarantool-version }}
+          TARANTOOL_SERVER_USER: root
+          TARANTOOL_SERVER_GROUP: root
+        run: ./mvnw -B test -P tarantool-container --file pom.xml
 
   merge-jacoco-report:
     name: Jacoco Merge Results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   ([#55](https://github.com/tarantool/testcontainers-java-tarantool/issues/55))
 - Change private modifier to protected modifier for fields and methods in TarantoolCartridgeContainer
 - Add `TARANTOOL_VERSION` environment variable support to TarantoolCartridgeContainer
-  `tarantool/tarantool:<TARANTOOL_VERSION>-centos7` if image name is omitted
+  `tarantool/tarantool:<TARANTOOL_VERSION>` if image name is omitted
   ([#102](https://github.com/tarantool/testcontainers-java-tarantool/pull/102))
 
 ## [1.1.0] - 2023-12-12

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,28 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>tarantool-container</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*TarantoolContainer*IT.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <logback.configurationFile>${logging.config}</logback.configurationFile>
+                                <logLevel>${logging.logLevel}</logLevel>
+                            </systemPropertyVariables>
+                            <trimStackTrace>false</trimStackTrace>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,7 @@
                             </includes>
                             <excludes>
                                 <exclude>**/*EnterpriseIT.java</exclude>
+                                <exclude>**/*TarantoolContainer*IT.java</exclude>
                             </excludes>
                             <systemPropertyVariables>
                                 <logback.configurationFile>${logging.config}</logback.configurationFile>

--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -18,8 +18,8 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer>
         implements TarantoolContainerOperations<TarantoolContainer> {
 
     public static final String TARANTOOL_IMAGE = "tarantool/tarantool";
-    public static final String DEFAULT_IMAGE_VERSION = "2.10.5";
-    public static final String DEFAULT_TARANTOOL_BASE_IMAGE = String.format("%s:%s-centos7", TARANTOOL_IMAGE, DEFAULT_IMAGE_VERSION);
+    public static final String DEFAULT_IMAGE_VERSION = "2.11.2-centos7";
+    public static final String DEFAULT_TARANTOOL_BASE_IMAGE = String.format("%s:%s", TARANTOOL_IMAGE, DEFAULT_IMAGE_VERSION);
 
 
     private static final String DEFAULT_HOST = "localhost";
@@ -386,7 +386,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer>
     private void setImageNameFromEnv() {
         String version = System.getenv("TARANTOOL_VERSION");
         if (version != null && !version.trim().isEmpty()) {
-            setDockerImageName(String.format("%s:%s-centos7", TARANTOOL_IMAGE, version));
+            setDockerImageName(String.format("%s:%s", TARANTOOL_IMAGE, version));
         }
     }
 }

--- a/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
@@ -25,6 +25,8 @@ public final class TarantoolContainerClientHelper {
             "Executed script %s with exit code %d, stderr: \"%s\", stdout: \"%s\"";
     private static final String EXECUTE_COMMAND_ERROR_TEMPLATE =
             "Executed command \"%s\" with exit code %d, stderr: \"%s\", stdout: \"%s\"";
+    // Generates bash command witch creates executable lua file with connection to required node
+    // and evaluation of needed lua code
     private static final String MTLS_COMMAND_TEMPLATE =
             "echo \" " +
                     "    print(require('yaml').encode( " +

--- a/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
@@ -35,7 +35,8 @@ public final class TarantoolContainerClientHelper {
                     "            ):eval('%s')}) " +
                     "        ); " +
                     "    os.exit(); " +
-                    "\" | tarantool";
+                    "\" > container-tmp.lua &&" +
+                    " tarantool container-tmp.lua";
     private static final String SSL_COMMAND_TEMPLATE =
             "echo \" " +
                     "    print(require('yaml').encode( " +
@@ -45,7 +46,8 @@ public final class TarantoolContainerClientHelper {
                     "            ):eval('%s')}) " +
                     "        ); " +
                     "    os.exit(); " +
-                    "\" | tarantool";
+                    "\" > container-tmp.lua &&" +
+                    " tarantool container-tmp.lua";
     private static final String COMMAND_TEMPLATE = "echo \" " +
             "    print(require('yaml').encode( " +
             "        {require('net.box').connect( " +
@@ -54,7 +56,8 @@ public final class TarantoolContainerClientHelper {
             "            ):eval('%s')}) " +
             "        ); " +
             "    os.exit(); " +
-            "\" | tarantool";
+            "\" > container-tmp.lua &&" +
+            " tarantool container-tmp.lua";
 
     TarantoolContainerClientHelper(TarantoolContainerOperations<? extends Container<?>> container) {
         this.container = container;

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,5 +1,5 @@
-ARG TARANTOOL_VERSION=2.11.0
-FROM tarantool/tarantool:${TARANTOOL_VERSION}-centos7 AS cartridge-base
+ARG TARANTOOL_VERSION=2.11.2-centos7
+FROM tarantool/tarantool:${TARANTOOL_VERSION} AS cartridge-base
 
 # system preparations because docker mount directory as a root
 ARG TARANTOOL_SERVER_USER="root"

--- a/src/test/java/org/testcontainers/containers/StaticTarantoolContainerIT.java
+++ b/src/test/java/org/testcontainers/containers/StaticTarantoolContainerIT.java
@@ -13,10 +13,11 @@ import static org.junit.Assert.assertEquals;
  * @author Ivan Dneprov
  */
 @Testcontainers
-public class TarantoolStaticContainerIT {
+public class StaticTarantoolContainerIT {
+    protected static final String tarantoolVersion = System.getenv().get("TARANTOOL_VERSION");
 
     @Container
-    private static final TarantoolContainer container = new TarantoolContainer();
+    protected static final TarantoolContainer container = new TarantoolContainer();
 
     @Test
     public void testExecuteCommand() throws Exception {

--- a/src/test/java/org/testcontainers/containers/TarantoolContainerIT.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolContainerIT.java
@@ -81,7 +81,9 @@ class TarantoolContainerIT {
         }
 
         assertEquals(1, result.size());
-        assertTrue(result.get(0).startsWith(String.valueOf(tarantoolVersion.charAt(0))));
+        if (tarantoolVersion != null) {
+            assertTrue(result.get(0).startsWith(String.valueOf(tarantoolVersion.charAt(0))));
+        }
     }
 
     @Test

--- a/src/test/java/org/testcontainers/containers/TarantoolContainerIT.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolContainerIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 class TarantoolContainerIT {
 
     private static final String ENV_TARANTOOL_VERSION = "TARANTOOL_VERSION";
+    protected static final String tarantoolVersion = System.getenv(ENV_TARANTOOL_VERSION);
 
     private void addEnv(String key, String value) throws NoSuchFieldException, IllegalAccessException {
         Class<?> classOfMap = System.getenv().getClass();
@@ -73,23 +74,6 @@ class TarantoolContainerIT {
 
     @Test
     public void testContainerWithTrueVersion() throws Exception {
-        final String version = "2.11.0";
-        addEnv(ENV_TARANTOOL_VERSION, version);
-
-        List<String> result;
-        try (TarantoolContainer container = new TarantoolContainer()) {
-            container.start();
-            result = container.executeCommandDecoded("return _TARANTOOL");
-        }
-
-        removeEnv(ENV_TARANTOOL_VERSION, version);
-        assertEquals(1, result.size());
-        assertTrue(result.get(0).startsWith(version));
-    }
-
-    @Test
-    public void testContainerWithDefaultVersionVersion() throws Exception {
-
         List<String> result;
         try (TarantoolContainer container = new TarantoolContainer()) {
             container.start();
@@ -97,7 +81,7 @@ class TarantoolContainerIT {
         }
 
         assertEquals(1, result.size());
-        assertTrue(result.get(0).startsWith(TarantoolContainer.DEFAULT_IMAGE_VERSION));
+        assertTrue(result.get(0).startsWith(String.valueOf(tarantoolVersion.charAt(0))));
     }
 
     @Test


### PR DESCRIPTION
- Add tarantool 3 support
- Add matrix tests with tarantool 1.x, 2.11.2 and 3.0.1
- Change TARANTOOL_VERSION usage (remove -centos7 from template for Tarantool 3 images)
- Add tarantool-container test profile for matrix tests
- Update DEFAULT_IMAGE_VERSION to 2.11.2

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
Closes #109