### PR TITLE
Use ubuntu 20.04 as default image os

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           TARANTOOL_SERVER_USER: root
           TARANTOOL_SERVER_GROUP: root
-          TARANTOOL_VERSION: "2.11.2-centos7"
+          TARANTOOL_VERSION: "2.11.2-ubuntu20.04"
         run: ./mvnw -B test -P integration -Djacoco.destFile=target/jacoco-cartridge-container.exec --file pom.xml
 
       - name: Upload jacoco exec results
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        tarantool-version: [ "1.x-centos7", "2.11.2-centos7", "3.0.1" ]
+        tarantool-version: [ "1.x-centos7", "2.11.2-ubuntu20.04", "3.0.1" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,6 +103,7 @@ jobs:
     needs:
       - tests-cartridge-container
       - tests-ee
+      - tests-tarantool-container
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.3.1] - 2024-02-13
+
+- Change `TARANTOOL_VERSION` default value from `2.11.2-centos7` to `2.11.2-ubuntu20.04` and update Dockerfile
+
 ## [1.3.0] - 2024-02-02
 
 - Change `TARANTOOL_VERSION` semantic. Now it's expected to be a full tag, not prefix of centos version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [1.3.1] - 2024-02-13
 
 - Change `TARANTOOL_VERSION` default value from `2.11.2-centos7` to `2.11.2-ubuntu20.04` and update Dockerfile
+  Because of issues with cartridge build on centos 7
 
 ## [1.3.0] - 2024-02-02
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.tarantool</groupId>
     <artifactId>testcontainers-java-tarantool</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0-SNAPSHOT-u</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>TestContainers for Tarantool</name>
     <description>Dockerized Tarantool and Tarantool Cartridge containers for testing under Testcontainers.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>io.tarantool</groupId>
     <artifactId>testcontainers-java-tarantool</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT-u</version>
 
     <name>TestContainers for Tarantool</name>
     <description>Dockerized Tarantool and Tarantool Cartridge containers for testing under Testcontainers.</description>

--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -18,7 +18,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer>
         implements TarantoolContainerOperations<TarantoolContainer> {
 
     public static final String TARANTOOL_IMAGE = "tarantool/tarantool";
-    public static final String DEFAULT_IMAGE_VERSION = "2.11.2-centos7";
+    public static final String DEFAULT_IMAGE_VERSION = "2.11.2-ubuntu20.04";
     public static final String DEFAULT_TARANTOOL_BASE_IMAGE = String.format("%s:%s", TARANTOOL_IMAGE, DEFAULT_IMAGE_VERSION);
 
 

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,26 +1,17 @@
 ARG TARANTOOL_VERSION=2.11.2-ubuntu20.04
 FROM tarantool/tarantool:${TARANTOOL_VERSION} AS cartridge-base
 
-# system preparations because docker mount directory as a root
-#ARG TARANTOOL_SERVER_USER="root"
-#ARG TARANTOOL_SERVER_GROUP="root"
-#USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
-#RUN groupadd $TARANTOOL_SERVER_GROUP && useradd -m -s /bin/bash $TARANTOOL_SERVER_USER || true
-
 # install dependencies
 # a yum bug requires setting ulimit, see https://bugzilla.redhat.com/show_bug.cgi?id=1537564
-RUN echo "test"
-RUN touch /etc/apt/sources.list
-RUN echo "deb http://mirror.yandex.ru/ubuntu focal main restricted\ndeb http://mirror.yandex.ru/ubuntu focal-updates main restricted\ndeb http://mirror.yandex.ru/ubuntu focal universe\ndeb http://mirror.yandex.ru/ubuntu focal-updates universe\ndeb http://mirror.yandex.ru/ubuntu focal multiverse\ndeb http://mirror.yandex.ru/ubuntu focal-updates multiverse\ndeb http://mirror.yandex.ru/ubuntu focal-backports main restricted universe multiverse\ndeb http://mirror.yandex.ru/ubuntu focal-security main restricted\ndeb http://mirror.yandex.ru/ubuntu focal-security universe\ndeb http://mirror.yandex.ru/ubuntu focal-security multiverse" > /etc/apt/sources.list
-RUN apt-get -y update
-RUN apt-get -y install build-essential
-RUN apt-get -y install cmake
-RUN apt-get -y install make
-RUN apt-get -y install gcc
-RUN apt-get -y install git
-RUN apt-get -y install unzip
-RUN apt-get -y install cartridge-cli
-RUN cartridge version
+RUN apt-get -y update && \
+    apt-get -y install build-essential && \
+    apt-get -y install cmake && \
+    apt-get -y install make && \
+    apt-get -y install gcc && \
+    apt-get -y install git && \
+    apt-get -y install unzip && \
+    apt-get -y install cartridge-cli && \
+    cartridge version
 
 # build and run
 FROM cartridge-base AS cartridge-app
@@ -43,8 +34,7 @@ ENV CMAKE_DUMMY_WEBUI="YES"
 COPY $CARTRIDGE_SRC_DIR $TARANTOOL_WORKDIR
 WORKDIR $TARANTOOL_WORKDIR
 
-RUN rm -rf .rocks
-RUN cartridge build --verbose
+RUN rm -rf .rocks && cartridge build --verbose
 
 RUN echo 'if [ -z "$TARANTOOL_CLUSTER_COOKIE" ]; then unset TARANTOOL_CLUSTER_COOKIE ; fi ; \
     sleep $START_DELAY && cartridge start --run-dir=$TARANTOOL_RUNDIR --data-dir=$TARANTOOL_DATADIR \

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -10,8 +10,10 @@ RUN apt-get -y update && \
     apt-get -y install gcc && \
     apt-get -y install git && \
     apt-get -y install unzip && \
-    apt-get -y install cartridge-cli && \
-    cartridge version
+RUN apt-get -y update && \
+    apt-get -y install build-essential cmake make gcc git unzip cartridge-cli && \
+    apt-get -y clean
+RUN cartridge version
 
 # build and run
 FROM cartridge-base AS cartridge-app

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -7,7 +7,8 @@ USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
 RUN groupadd $TARANTOOL_SERVER_GROUP && useradd -m -s /bin/bash $TARANTOOL_SERVER_USER || true
 
 # install dependencies
-RUN apt-get -y update && \
+RUN ulimit -n 1024 && \
+    apt-get -y update && \
     apt-get -y install build-essential cmake make gcc git unzip cartridge-cli && \
     apt-get -y clean
 RUN cartridge version

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -4,13 +4,6 @@ FROM tarantool/tarantool:${TARANTOOL_VERSION} AS cartridge-base
 # install dependencies
 # a yum bug requires setting ulimit, see https://bugzilla.redhat.com/show_bug.cgi?id=1537564
 RUN apt-get -y update && \
-    apt-get -y install build-essential && \
-    apt-get -y install cmake && \
-    apt-get -y install make && \
-    apt-get -y install gcc && \
-    apt-get -y install git && \
-    apt-get -y install unzip && \
-RUN apt-get -y update && \
     apt-get -y install build-essential cmake make gcc git unzip cartridge-cli && \
     apt-get -y clean
 RUN cartridge version

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,8 +1,12 @@
 ARG TARANTOOL_VERSION=2.11.2-ubuntu20.04
 FROM tarantool/tarantool:${TARANTOOL_VERSION} AS cartridge-base
 
+ARG TARANTOOL_SERVER_USER="root"
+ARG TARANTOOL_SERVER_GROUP="root"
+USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
+RUN groupadd $TARANTOOL_SERVER_GROUP && useradd -m -s /bin/bash $TARANTOOL_SERVER_USER || true
+
 # install dependencies
-# a yum bug requires setting ulimit, see https://bugzilla.redhat.com/show_bug.cgi?id=1537564
 RUN apt-get -y update && \
     apt-get -y install build-essential cmake make gcc git unzip cartridge-cli && \
     apt-get -y clean

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,17 +1,25 @@
-ARG TARANTOOL_VERSION=2.11.2-centos7
+ARG TARANTOOL_VERSION=2.11.2-ubuntu20.04
 FROM tarantool/tarantool:${TARANTOOL_VERSION} AS cartridge-base
 
 # system preparations because docker mount directory as a root
-ARG TARANTOOL_SERVER_USER="root"
-ARG TARANTOOL_SERVER_GROUP="root"
-USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
-RUN groupadd $TARANTOOL_SERVER_GROUP && useradd -m -s /bin/bash $TARANTOOL_SERVER_USER || true
+#ARG TARANTOOL_SERVER_USER="root"
+#ARG TARANTOOL_SERVER_GROUP="root"
+#USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
+#RUN groupadd $TARANTOOL_SERVER_GROUP && useradd -m -s /bin/bash $TARANTOOL_SERVER_USER || true
 
 # install dependencies
 # a yum bug requires setting ulimit, see https://bugzilla.redhat.com/show_bug.cgi?id=1537564
-RUN ulimit -n 1024 && \
-    yum -y install cmake make gcc gcc-c++ git unzip cartridge-cli && \
-    yum clean all
+RUN echo "test"
+RUN touch /etc/apt/sources.list
+RUN echo "deb http://mirror.yandex.ru/ubuntu focal main restricted\ndeb http://mirror.yandex.ru/ubuntu focal-updates main restricted\ndeb http://mirror.yandex.ru/ubuntu focal universe\ndeb http://mirror.yandex.ru/ubuntu focal-updates universe\ndeb http://mirror.yandex.ru/ubuntu focal multiverse\ndeb http://mirror.yandex.ru/ubuntu focal-updates multiverse\ndeb http://mirror.yandex.ru/ubuntu focal-backports main restricted universe multiverse\ndeb http://mirror.yandex.ru/ubuntu focal-security main restricted\ndeb http://mirror.yandex.ru/ubuntu focal-security universe\ndeb http://mirror.yandex.ru/ubuntu focal-security multiverse" > /etc/apt/sources.list
+RUN apt-get -y update
+RUN apt-get -y install build-essential
+RUN apt-get -y install cmake
+RUN apt-get -y install make
+RUN apt-get -y install gcc
+RUN apt-get -y install git
+RUN apt-get -y install unzip
+RUN apt-get -y install cartridge-cli
 RUN cartridge version
 
 # build and run
@@ -31,10 +39,12 @@ ENV TARANTOOL_DATADIR=$TARANTOOL_DATADIR
 ENV TARANTOOL_LOGDIR=$TARANTOOL_LOGDIR
 ENV TARANTOOL_INSTANCES_FILE=$TARANTOOL_INSTANCES_FILE
 ENV TARANTOOL_CLUSTER_COOKIE=$TARANTOOL_CLUSTER_COOKIE
+ENV CMAKE_DUMMY_WEBUI="YES"
 COPY $CARTRIDGE_SRC_DIR $TARANTOOL_WORKDIR
 WORKDIR $TARANTOOL_WORKDIR
 
-RUN rm -rf .rocks && cartridge build --verbose
+RUN rm -rf .rocks
+RUN cartridge build --verbose
 
 RUN echo 'if [ -z "$TARANTOOL_CLUSTER_COOKIE" ]; then unset TARANTOOL_CLUSTER_COOKIE ; fi ; \
     sleep $START_DELAY && cartridge start --run-dir=$TARANTOOL_RUNDIR --data-dir=$TARANTOOL_DATADIR \


### PR DESCRIPTION
Change `TARANTOOL_VERSION` default value from `2.11.2-centos7` to `2.11.2-ubuntu20.04`. 
It ruined rocks building due to certificate issues on centos.

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
Closes #119