### PR TITLE
gh-126: Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.4.0] - 2025-07-24
+- Bump testcontainers.version from 1.19.3 to 1.21.3
+- Bump jackson-annotations from 2.14.0 to 2.18.4
+- Bump slf4j-api from 2.0.3 to 2.0.17
+- Bump snakeyaml from 2.0 to 2.3
+- Bump httpclient from 4.5.1 to 4.5.14
+- Bump logback-classic from 1.3.4 to 1.3.15
+- Bump junit-jupiter from 5.8.1 to 5.13.3
+
 ## [1.3.3] - 2024-05-06
 - Add support for environment variable `TARANTOOL_REGISTRY`
 - Remove enterprise tests

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>io.tarantool</groupId>
   <artifactId>testcontainers-java-tarantool</artifactId>
-  <version>1.3.3</version>
+  <version>1.4.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </scm>
 
     <properties>
-        <testcontainers.version>1.19.3</testcontainers.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <logging.config>${project.basedir}/src/test/resources/logback-test.xml</logging.config>
@@ -65,12 +65,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.14.0</version>
+                <version>2.18.4</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.3</version>
+                <version>2.0.17</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>2.0</version>
+            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -95,21 +95,21 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>4.5.14</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.3.4</version>
+            <version>1.3.15</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.8.1</version>
+            <version>5.13.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Bump testcontainers.version from 1.19.3 to 1.21.3
- Bump jackson-annotations from 2.14.0 to 2.18.4
- Bump slf4j-api from 2.0.3 to 2.0.17
- Bump snakeyaml from 2.0 to 2.3
- Bump httpclient from 4.5.1 to 4.5.14
- Bump logback-classic from 1.3.4 to 1.3.15
- Bump junit-jupiter from 5.8.1 to 5.13.


I haven't forgotten about:
- [ ] Tests
- [ ] Changelog
- [ ] Documentation
- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [ ] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #126 