### PR TITLE
release: prepare release 1.5.0

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,7 +44,7 @@ To enable automatic releases, you need to configure the following secrets in you
 ## Release Process
 
 ### Automatic Release
-1. Create and push a new tag with semantic versioning format (e.g., `git tag 1.4.1 && git push origin 1.4.1`)
+1. Create and push a new tag with semantic versioning format (e.g., `git tag 1.5.0 && git push origin 1.5.0`)
 2. The release workflow will automatically:
    - Build and test the project
    - Sign the artifacts with GPG

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -6,7 +6,7 @@ on:
       releaseVersion:
         description: 'Release and tag version'
         required: true
-        default: "v1.5.0"
+        default: "v1.6.0"
       developmentVersion:
         description: 'Version to use for new working copy'
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+## [1.5.0] - 2025-12-05
 - Bump org.testcontainers from 1.21.3 to 2.0.1
 - Bump logback-classic from 1.3.15 to 1.3.16
 - Change `TARANTOOL_VERSION` default value from `2.11.2-ubuntu20.04` to `2.11.8-ubuntu20.04`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>io.tarantool</groupId>
   <artifactId>testcontainers-java-tarantool</artifactId>
-  <version>1.4.1</version>
+  <version>1.5.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
- Update READMEs
- Set next version for next iteration in GitHub workflows

I haven't forgotten about:
- [ ] Tests
- [x] Changelog
- [x] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->